### PR TITLE
修改R键菜单，修复ooi

### DIFF
--- a/overrides/minemenu/menu.json
+++ b/overrides/minemenu/menu.json
@@ -126,7 +126,7 @@
       "action": {
         "command": {
           "command": "/purge",
-          "clipboard": true
+          "clipboard": false
         }
       }
     }

--- a/overrides/scripts/tweaks/ooi.zs
+++ b/overrides/scripts/tweaks/ooi.zs
@@ -15,8 +15,7 @@ ConversionItem.create(<thermalfoundation:material:866>).addMatchItem(<ore:crysta
 ConversionItem.create(<mekanism:fluoriteclump>).addMatchItem(<ore:gemFluorite>).register();
 ConversionItem.create(<botania:quartztypemana>).addMatchItem(<ore:blockQuartzMana>).register();
 ConversionItem.create(<thebetweenlands:scabyst_block>).addMatchItem(<ore:blockScabyst>).register();
-ConversionItem.create(<additions:sulfur_ingot>).addMatchItem(<ore:gemSulfur>)
-    .addMatchItem(<ore:ingotSulfur>)
+ConversionItem.create(<additions:sulfur_ingot>).addMatchItem(<ore:ingotSulfur>)
     .addMatchItem(<betterendforge:crystalline_sulphur>)
     .addMatchItem(<betterendforge:sulphur_crystal>).register();
 ConversionItem.create(<tiths:nitre>).addMatchItem(<ore:dustSaltpeter>).register();


### PR DESCRIPTION
R键菜单清理掉落物功能的模式错了，导致命令被复制到剪切板而不是执行
ooi合并了交错的硫磺，导致活化器配方全部罢工