### PR TITLE
修复琥珀块不能合成的bug

### DIFF
--- a/overrides/scripts/recipes/vanilla/crafting_table/shaped2.zs
+++ b/overrides/scripts/recipes/vanilla/crafting_table/shaped2.zs
@@ -23,6 +23,7 @@ recipes.remove(<ymadditions:network_hub>);
 recipes.remove(<tconstruct:piggybackpack>.withTag({}));
 recipes.removeByRecipeName("biomesoplenty:amber_block");
 recipes.removeByRecipeName("biomesoplenty:amber");
+recipes.removeByRecipeName("betterendforge:amber_block");
 
 RecipeUtil.addShaped("calculator_subsystem_l4", <ecoaeextension:extendable_calculator_subsystem_l4>, [
     [<ecoaeextension:ecalculator_casing>, <additions:calculation_processor_2>, <ecoaeextension:ecalculator_casing>],
@@ -519,3 +520,8 @@ RecipeUtil.addModeRecipe("mm_upgrade_t1", <modularmachinery:blockcasing:1>, [
     [<ore:blockStainlessSteel>, <ore:ingotModularium>, <ore:blockStainlessSteel>]
 ]);
 
+RecipeUtil.addShaped("<thaumcraft_amber_block>", <thaumcraft:amber_block>, [
+    [<thaumcraft:amber>, <thaumcraft:amber>, null],
+    [<thaumcraft:amber>, <thaumcraft:amber>, null],
+    [null, null, null]
+]);


### PR DESCRIPTION
ooi合并琥珀块后，betterend的配方顶掉了神秘的配方，导致琥珀块无法合成（JEI有配方无法合成）