### PR TITLE
修复一级矿机结构

### DIFF
--- a/minecraft/config/modularmachinery/machinery/lv1_miner_basic.json
+++ b/minecraft/config/modularmachinery/machinery/lv1_miner_basic.json
@@ -3396,7 +3396,7 @@
             "y": 12,
             "z": 4,
             "elements": [
-                "appliedenergistics2:sky_stone_small_brick_double_slab@0"
+                "appliedenergistics2:sky_stone_small_brick@0"
             ]
         },
         {
@@ -5524,7 +5524,7 @@
             "y": 12,
             "z": 5,
             "elements": [
-                "appliedenergistics2:sky_stone_small_brick_double_slab@0"
+                "appliedenergistics2:sky_stone_small_brick@0"
             ]
         },
         {


### PR DESCRIPTION
顶上两个半砖叠一起无法被mmce识别搭建，直接改成一个整砖