### PR TITLE
直接移除锰的阶段

### DIFF
--- a/minecraft/scripts/gamestages/items.zs
+++ b/minecraft/scripts/gamestages/items.zs
@@ -138,7 +138,6 @@ GameStagesUtil.stageGettingStarted.addIngredients([
     <ore:dustGold>,
     <ore:blockIron>,
     <ore:blockGold>,
-    <ore:ingotManganese>
 ], false);
 
 GameStagesUtil.stageFusionMatrix.addIngredients([

--- a/minecraft/scripts/gamestages/restage.zs
+++ b/minecraft/scripts/gamestages/restage.zs
@@ -46,6 +46,7 @@ GameStagesUtil.removeItemStages([
     <nuclearcraft:ingot:8>,
     <nuclearcraft:dust:8>,
     <nuclearcraft:gem:6>,
+    <nuclearcraft:ingot:11>,
     <nuclearcraft:dust:11>,
     <extendedcrafting:material:129>,
     <extendedcrafting:material:128>,


### PR DESCRIPTION
ooi把核电和add的锰合并了，然后itemstage把add的锰认成了nc的锰，给加到核电的epic阶段了，导致锰在gettingstart和epicengineer之间反复横跳。每次开游戏锰的阶段都可能不一样。
直接把锰的阶段删了